### PR TITLE
Update to README.md so that DeBoot can be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-🚨 ATTENTION 🚨
-This repo is under construction! If you want to get involved, join us at #deboot:matrix.org
-
 # DeBoot
 
-DeBoot is a project to research and implement approaches to bootloading OS images from a decentralized storage network such as Swarm or IPFS.
+DeBoot is a project to research and implement approaches to bootloading OS images from decentralized storage networks, such as [Swarm](https://ethswarm.org) or [IPFS](https://ipfs.tech/).
+
+## Get involved
+
+If you want to get involved, join [the DeBoot chat on Matrix](https://matrix.to/#/#deboot:matrix.org) or the (less active) [DeBoot chat on Telegram](https://t.me/+hd2JXtyitYw0ZWE9).
 
 ## Repo contents
 
@@ -19,11 +20,15 @@ DeBoot is a project to research and implement approaches to bootloading OS image
 
 `/swarm.hash`. Swarm hashes of premade rootfs.
 
-## Running tests.
+## Running DeBoot
 
-You'll need Linux, Podman, and preferably a KVM-ready OS. 
+You'll need a KVM-ready Linux OS. Your Linux OS is KVM-ready if a file exists at `/dev/kvm`.
 
-1. `cd` into `/grub`, and run the following commands:
+1. Install `podman` using [these instructions](https://podman.io/docs/installation).
+
+2. Clone this repo using `git`, adding the `--recurse-submodules` flag.
+
+3. Change directory to `deboot/grub`, and run the following commands:
    
    ```sh
    ./init-image.sh
@@ -32,23 +37,33 @@ You'll need Linux, Podman, and preferably a KVM-ready OS.
    
    If you run the first command as root, the files created will be owned by root and you will have to go through the rest of the process as root. The second command needs to be run through `sudo`.
    
-1. Download the system container image provided [here](https://github.com/dracutdevs/dracut/pkgs/container/fedora) by the dracut devs, and run it with the command
+4. Download the system container image provided [here](https://github.com/dracutdevs/dracut/pkgs/container/fedora) by the dracut devs, by running:
+
+   ```sh
+   podman pull ghcr.io/dracutdevs/fedora:latest
+   ```
+
+5. Run the container image with the command:
    
    ```sh
    podman run --rm -ti --cap-add=SYS_PTRACE --user 0 \
-     -v /dev:/dev -v $PATH_TO_REPO:/deboot:z \
-     $CONTAINER bash -l
+     -v /dev:/dev -v $FULL_PATH_TO_REPO:/deboot:z \
+     ghcr.io/dracutdevs/fedora:latest bash -l
    ```
 
    These instructions are for running rootless (i.e. as an ordinary user). If you decide to run as root as well, you need to add the `--privileged` flag or KVM will not work. For more information, see [dracut/docs/HACKING.md](https://github.com/dracutdevs/dracut/blob/master/docs/HACKING.md).
    
-3. Change directory to `/deboot` and run `make` to generate the Swarm initramfs, `grub.cfg`, and use them to populate the GRUB image.
+6. Change directory to `deboot/dracut` and run `./configure` then `make`.
 
-4. Change directory back to `/grub`, and run `./test-grub.sh`. 
+7. Change directory to `..` and set the KVERSION variable to the kernel version by running `export KVERSION=$(ls /lib/modules)`.
+
+8. Run `make`, which will generate the Swarm initramfs (`grub.cfg`) and populate the GRUB image.
+    
+9. Change directory to `grub`, and run `./test-grub.sh`.
 
    This step can be run outside the container, but you'll need to set the `BIOS` environment variable to the path to an OVMF platform firmware image. This path depends on distribution.
 
-5. When you're done testing, clean up after yourself with `./unmount-image.sh`.
+10. When you're done testing, clean up after yourself with `sudo ./unmount-image.sh`.
 
 ## What?
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 🚨 ATTENTION 🚨
-This repo is under construction! If you want to get involved, join us on Telegram: https://t.me/+TnD8PDmVUIdjZWE1
+This repo is under construction! If you want to get involved, join us at #deboot:matrix.org
 
 # DeBoot
 


### PR DESCRIPTION
Added missing steps, and clarified a few points. @awmacpherson the KVERSION bit could benefit from your bash proficiency as right now it's functional but ugly-looking.

Added links to Swarm, IPFS, DeBoot matrix and telegram channels.

Removed "under construction" warning.